### PR TITLE
Update Installation Instructions

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -10,6 +10,11 @@ bower install gnosisjs
 ```
 
 # Build
+#### install pre-requisite package
+```
+$ npm install -g webpack
+```
+#### then
 
 ```
 $ cd gnosis.js


### PR DESCRIPTION
remove assumption of a globally installed npm package as a pre-requisite to running command "webpack"